### PR TITLE
ci: add sync-plugin-version workflow

### DIFF
--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -1,0 +1,59 @@
+name: Sync plugin.json version
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute target version from tag
+        id: ver
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Update plugin.json
+        run: |
+          if [ ! -f plugin.json ]; then echo "no plugin.json; skipping"; exit 0; fi
+          CURRENT=$(python3 -c "import json; print(json.load(open('plugin.json')).get('version',''))")
+          TARGET="${{ steps.ver.outputs.version }}"
+          if [ "$CURRENT" = "$TARGET" ]; then
+            echo "plugin.json already at $TARGET; no action"
+            exit 0
+          fi
+          python3 -c "
+          import json
+          p = json.load(open('plugin.json'))
+          p['version'] = '$TARGET'
+          json.dump(p, open('plugin.json', 'w'), indent=2)
+          open('plugin.json', 'a').write('\n')
+          "
+      - name: Open sync PR if plugin.json changed
+        run: |
+          if git diff --quiet plugin.json; then
+            echo "no changes"
+            exit 0
+          fi
+          BRANCH="chore/sync-plugin-version-${{ steps.ver.outputs.tag }}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add plugin.json
+          git commit -m "chore: sync plugin.json version to ${{ steps.ver.outputs.tag }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: sync plugin.json version to ${{ steps.ver.outputs.tag }}" \
+            --body "Triggered by release ${{ steps.ver.outputs.tag }}. Auto-sync to prevent drift. Closes workflow-registry#37."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Installs `.github/workflows/sync-plugin-version.yml` which auto-bumps `plugin.json` version to match the git tag on every `v*` tag push. Prevents plugin.json/tag drift. Closes GoCodeAlone/workflow-registry#37.