### PR TITLE
ci(release): fix listReleases draft-publish + bump v0.5.6 (C5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,13 @@ jobs:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             const { owner, repo } = context.repo;
-            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
+            // creates releases as draft; this step flips them to non-draft post-publish.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const release = releases.find(r => r.tag_name === tag);
+            if (!release) {
+              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
+            }
             if (release.draft) {
               await github.rest.repos.updateRelease({
                 owner,

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-websocket",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "author": "GoCodeAlone",
     "description": "General-purpose WebSocket support for workflow applications",
     "type": "external",


### PR DESCRIPTION
## Summary
- Fixes `getReleaseByTag` → `listReleases` in `Publish GitHub release` step
- Bumps `plugin.json` version to v0.5.6

## Test plan
- [ ] CI passes on merge
- [ ] Tag v0.5.6 triggers release workflow